### PR TITLE
Adicionando autenticacao basica

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,25 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>5.3.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.3.1.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <exclusions>
@@ -68,6 +87,16 @@
                     <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/br/com/codenation/desafio/config/AuthenticationServerConfiguration.java
+++ b/src/main/java/br/com/codenation/desafio/config/AuthenticationServerConfiguration.java
@@ -1,0 +1,43 @@
+package br.com.codenation.desafio.config;
+
+import br.com.codenation.desafio.constants.OAuthUser;
+import br.com.codenation.desafio.login.LoggedUser;
+import br.com.codenation.desafio.model.User;
+import br.com.codenation.desafio.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+
+@Configuration
+@EnableAuthorizationServer
+public class AuthenticationServerConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public AuthenticationManager customAuthenticationManager() throws Exception {
+        return authenticationManagerBean();
+    }
+
+    @Autowired
+    protected void configure(AuthenticationManagerBuilder auth, UserRepository userRepository) throws Exception {
+        if (userRepository.count() == 0) {
+            userRepository.save(User.builder()
+                    .email(OAuthUser.email)
+                    .password(passwordEncoder().encode(OAuthUser.password))
+                    .nome(OAuthUser.name)
+                    .build());
+        }
+        auth.userDetailsService(email -> userRepository.findByEmail(email)
+                .map(LoggedUser::new)
+                .orElse(null)).passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/br/com/codenation/desafio/config/AuthorizationServerConfig.java
+++ b/src/main/java/br/com/codenation/desafio/config/AuthorizationServerConfig.java
@@ -1,0 +1,49 @@
+package br.com.codenation.desafio.config;
+
+import br.com.codenation.desafio.constants.OAuthClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+
+@Configuration
+@EnableAuthorizationServer
+public class AuthorizationServerConfig  extends AuthorizationServerConfigurerAdapter {
+
+    private static final int ACCESS_TOKEN_VALIDITY_IN_SECONDS = 60 * 20;
+    private static final int REFRESH_TOKEN_VALIDITY_IN_SECONDS = 60 * 60;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+        security.tokenKeyAccess("permitAll()")
+                .checkTokenAccess("isAuthenticated()")
+                .allowFormAuthenticationForClients();
+    }
+
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        clients.inMemory()
+                .withClient(OAuthClient.clientId)
+                .secret(new BCryptPasswordEncoder().encode(OAuthClient.clientSecret))
+                .authorizedGrantTypes(OAuthClient.grantTypes)
+                .scopes(OAuthClient.scopes)
+                .accessTokenValiditySeconds(ACCESS_TOKEN_VALIDITY_IN_SECONDS)
+                .refreshTokenValiditySeconds(REFRESH_TOKEN_VALIDITY_IN_SECONDS);
+    }
+
+    @Override
+    public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+        endpoints.authenticationManager(authenticationManager)
+                .allowedTokenEndpointRequestMethods(HttpMethod.GET, HttpMethod.POST);
+    }
+}

--- a/src/main/java/br/com/codenation/desafio/config/ResourceServerConfig.java
+++ b/src/main/java/br/com/codenation/desafio/config/ResourceServerConfig.java
@@ -1,0 +1,19 @@
+package br.com.codenation.desafio.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+
+@Configuration
+@EnableResourceServer
+public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .antMatchers(HttpMethod.GET, "/oauthtest").authenticated()
+                .anyRequest().permitAll();
+    }
+}

--- a/src/main/java/br/com/codenation/desafio/constants/OAuthClient.java
+++ b/src/main/java/br/com/codenation/desafio/constants/OAuthClient.java
@@ -1,0 +1,14 @@
+package br.com.codenation.desafio.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+public class OAuthClient {
+
+    public static final String clientId = "client-id";
+    public static final String clientSecret = "client-secret";
+    public static final String[] grantTypes = {"password", "authorization_code", "refresh_token", "implicit"};
+    public static final String[] scopes = {"read", "write", "trust"};
+}

--- a/src/main/java/br/com/codenation/desafio/constants/OAuthUser.java
+++ b/src/main/java/br/com/codenation/desafio/constants/OAuthUser.java
@@ -1,0 +1,8 @@
+package br.com.codenation.desafio.constants;
+
+public class OAuthUser {
+
+    public static final String email = "admin@admin.com";
+    public static final String password = "admin";
+    public static final String name = "Admin";
+}

--- a/src/main/java/br/com/codenation/desafio/controller/OAuthTestController.java
+++ b/src/main/java/br/com/codenation/desafio/controller/OAuthTestController.java
@@ -1,0 +1,14 @@
+package br.com.codenation.desafio.controller;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OAuthTestController {
+
+    @GetMapping("/oauthtest")
+    public String oauthtest(){
+        return "Somente mostrado se usuário estiver logado.";
+    }
+}

--- a/src/main/java/br/com/codenation/desafio/login/LoggedUser.java
+++ b/src/main/java/br/com/codenation/desafio/login/LoggedUser.java
@@ -1,0 +1,51 @@
+package br.com.codenation.desafio.login;
+
+import br.com.codenation.desafio.model.User;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoggedUser implements UserDetails {
+
+    private User user;
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/br/com/codenation/desafio/model/User.java
+++ b/src/main/java/br/com/codenation/desafio/model/User.java
@@ -51,7 +51,6 @@ public class User {
     private String email;
 	
     @NotNull
-    @Size(min = 6, max = 20)
     private String password;
 	
     private String token;

--- a/src/test/java/br/com/codenation/desafio/model/UserTest.java
+++ b/src/test/java/br/com/codenation/desafio/model/UserTest.java
@@ -86,25 +86,6 @@ public class UserTest {
 	}
 	
 	@Test
-	public void userPasswordIsNotValid() {
-		User user = User.builder()
-				.email("john.doe@gmail.com")
-				.nome("John Doe")
-				.password("12345")
-				.createdAt(LocalDateTime.now())
-				.build();
-		
-        Set<ConstraintViolation<User>> constraintViolations = validator
-        		.validate(user);
-        
-        assertEquals(1, constraintViolations.size());
-        
-        constraintViolations.forEach(
-        		cv -> System.out.println(cv.getPropertyPath() + " " + cv.getMessage())
-        		);
-	}
-	
-	@Test
 	public void userIsValid() {
 		User user = User.builder()
 				.email("john.doe@gmail.com")

--- a/src/test/java/br/com/codenation/desafio/oauth/OAuthTest.java
+++ b/src/test/java/br/com/codenation/desafio/oauth/OAuthTest.java
@@ -1,0 +1,103 @@
+package br.com.codenation.desafio.oauth;
+
+import br.com.codenation.desafio.config.AuthenticationServerConfiguration;
+import br.com.codenation.desafio.constants.OAuthClient;
+import br.com.codenation.desafio.model.User;
+import br.com.codenation.desafio.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.json.JacksonJsonParser;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class OAuthTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthenticationServerConfiguration authenticationServerConfiguration;
+
+    private MockMvc mockMvc;
+
+    private final String userEmail = "oauth@teste.com";
+    private final String userPassword = "password";
+
+    @Before
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+
+    private User createUser() {
+        User user = User.builder()
+                .nome("Teste")
+                .email(userEmail)
+                .password(authenticationServerConfiguration.passwordEncoder().encode(userPassword))
+                .createdAt(LocalDateTime.now())
+                .build();
+        return userRepository.save(user);
+    }
+
+    @Test
+    @Transactional
+    public void givenAuthRequestOnPrivateWithTokenShouldResponseOk() throws Exception {
+        createUser();
+        mockMvc.perform(MockMvcRequestBuilders.get("/oauthtest")
+                .header("Authorization", "Bearer " + obtainAccessToken())
+                .accept(MediaType.ALL))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Somente mostrado se usuário estiver logado.")));
+    }
+
+    @Test
+    public void givenAuthRequestOnPrivateWithoutTokenShouldResponseUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/oauthtest")
+                .accept(MediaType.ALL))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String obtainAccessToken() throws Exception {
+        String encodedCredentials = Base64.getEncoder().encodeToString(
+                (OAuthClient.clientId + ":" + OAuthClient.clientSecret).getBytes());
+        String authorizationHeader = "Basic " + encodedCredentials;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+                .post("/oauth/token?username="+ userEmail +
+                        "&password=" + userPassword + "&grant_type=password")
+                .header("Authorization", authorizationHeader)
+                .accept(MediaType.ALL))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
+
+        String resultString = result.andReturn().getResponse().getContentAsString();
+        JacksonJsonParser jsonParser = new JacksonJsonParser();
+        return jsonParser.parseMap(resultString).get("access_token").toString();
+    }
+}


### PR DESCRIPTION
>Descrição

Adição de autenticação básica

> Como usar

Somente o endpoint oauthtest (`será excluido posteriormente`) está com autenticação.

Exemplo curl para pegar token:

```
curl --request POST \
  --url 'http://localhost:8080/oauth/token?username=admin@admin.com&password=admin&grant_type=password' \
  --header 'authorization: Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ=' 
```

> Comentário

Em `src/main/java/br/com/codenation/desafio/constants`

Coloquei as constantes de acesso, como clientId, clientSecret, usuário de admin e etc.

> Mudanças

- Foi necessário tirar a validação de senha, pois será criptografada, conforme aula do professor.
