### PR TITLE
Adicao docker-compose para setup do db local

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Desafio Final Central de Erros - backend
 
+
+Quick start
+===========
+
+
+| Step                       | Command                         |
+| ---------------------------|:-------------------------------:|
+| Setup Banco de dados       | ``$ docker-compose up --build`` |
+| Rodar aplicação            | Rodar o Application             |
+
+
+
 Descrição...
 
 **Equipe backend**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres-network
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "postgres@postgres.com"
+      PGADMIN_DEFAULT_PASSWORD: "postgres"
+    ports:
+      - "16543:80"
+    depends_on:
+      -  postgres
+    networks:
+      - postgres-network
+
+networks:
+  postgres-network:
+    driver: bridge


### PR DESCRIPTION
> Feature

Adição de um docker compose para levantar um banco de dados, com o pgadmin local e facilitar para test rápido.

> Descrição

Na raiz:

```
- docker-compose up
```
